### PR TITLE
Added ability to link swift objects to gobjects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ undocumented.json
 Package.resolved
 Package.pins
 *-*.swift
+Sources/GLibObject/*-*.swift.out

--- a/Sources/GLibObject/GLibObject.swift
+++ b/Sources/GLibObject/GLibObject.swift
@@ -286,7 +286,11 @@ public extension ObjectProtocol {
 
 //MARK:- Swift Object
 
-public let swiftObjKey = "swiftobj";
+let swiftObjKey = "swiftobj";
+
+let gtrue: gboolean = 1
+
+let gfalse: gboolean = 0
 
 public extension GLibObject.ObjectProtocol {
 	

--- a/Sources/GLibObject/GLibObject.swift
+++ b/Sources/GLibObject/GLibObject.swift
@@ -283,3 +283,67 @@ public extension ObjectProtocol {
         return bind(source_property, to: target, property: target_property, flags: fl, transformFrom: ft, transformTo: gt)
     }
 }
+
+//MARK:- Swift Object
+
+public let swiftObjKey = "swiftobj";
+
+public extension GLibObject.ObjectProtocol {
+	
+	/// The swift wrapper for this object.
+	public var swiftObj: AnyObject? {
+		get {
+			let pointer = getData(key: swiftObjKey);
+			if pointer != nil {
+				return Unmanaged<AnyObject>.fromOpaque(pointer!).takeUnretainedValue();
+			} else {
+				return nil;
+			}
+		}
+		nonmutating set {
+			// Setting swift object to the already existing swiftObj is a no-op, in order to avoid duplicate toggleRefs, which never fire and thus cause reference cycles.
+			guard let newValue = newValue, newValue !== swiftObj else {
+				return
+			}
+			// Get a strong pointer to swiftObj
+			let pointer = Unmanaged<AnyObject>.passRetained(newValue).toOpaque();
+			setData(key: swiftObjKey, data: pointer);
+			// In the majority of cases, swiftObj will be the swift wrapper for this gobject's c implementation. To prevent orphaning, these should be equivalent for memory management purposes; If one is referenced, the other is referenced. A naive way to implement this is to have both strongly reference each other, but this creates a strong reference cycle. Therefore, the wrapper has a strong toggle reference to the gobject, which tells us when there are other references. In this instance, the wrapper should be referenced, so the gobject strongly references it. Otherwise, the gobject weakly references it, allowing it, and thus the gobject, to be released once it is not referenced in swift-space.
+			addToggleRef { (_, selfPointer, lastRef) in
+				let swiftObjPointer = Unmanaged<AnyObject>.fromOpaque(g_object_get_data(selfPointer, swiftObjKey));
+				switch lastRef {
+				case gfalse:
+					// Make the gobject strongly reference the wrapper.
+					swiftObjPointer.retain();
+				case gtrue:
+					// Make the gobject weakly reference the wrapper.
+					swiftObjPointer.release();
+				default:
+					break;
+				}
+			}
+			// Release the regular reference so we don't have two references from the wrapper.
+			unref();
+		}
+	}
+	
+}
+
+public extension GLibObject.Object {
+	
+	/// Will set this swift instance to be the swiftObj.
+	public func becomeSwiftObj() {
+		swiftObj = self;
+	}
+	
+}
+
+/// Fetches the swift object from the given pointers, if any. Assume pointer is a GObject, so only call this function if this is known.
+public func swiftObj(fromRaw raw: UnsafeMutableRawPointer) -> AnyObject? {
+	let objPointer = g_object_get_data(raw.assumingMemoryBound(to: GObject.self), swiftObjKey);
+	if let objPointer = objPointer {
+		return Unmanaged<AnyObject>.fromOpaque(objPointer).takeUnretainedValue();
+	} else {
+		return nil;
+	}
+}


### PR DESCRIPTION
This pull requests improves bridging between swift objects and gobjects by allowing gobjects to store and reference their wrappers, and allows references to the gobject to serve as references to the swift wrapper.